### PR TITLE
Add requirements file for python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+keyboard
+pyperclip
+pillow
+pystray


### PR DESCRIPTION
## Summary
- include `requirements.txt` listing non-default packages

## Testing
- `python -m py_compile script.py clip2file_tray.py spinner.py`


------
https://chatgpt.com/codex/tasks/task_e_685098b098d4832aac55fece06392dcd