### PR TITLE
Fix asset paths

### DIFF
--- a/src/pasteasfile/clip2file_tray.py
+++ b/src/pasteasfile/clip2file_tray.py
@@ -46,11 +46,11 @@ def on_exit(icon, _item):
 
 def setup_tray():
     if getattr(sys, "frozen", False):
-        base_path = sys._MEIPASS
+        base_path = pathlib.Path(sys._MEIPASS)
     else:
-        base_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "assets")
-    icon_path = os.path.join(base_path, "icon.ico")
-    image = Image.open(icon_path)
+        base_path = pathlib.Path(__file__).resolve().parents[2] / "assets"
+    icon_path = base_path / "icon.ico"
+    image = Image.open(str(icon_path))
     menu  = pystray.Menu(pystray.MenuItem("Exit", on_exit))
     icon  = pystray.Icon("Paste as File", image, "Paste as File", menu)
     threading.Thread(target=icon.run, daemon=True).start()
@@ -65,4 +65,4 @@ if __name__ == "__main__":
 
 # debug: watchmedo auto-restart --patterns="*.py" --recursive -- python clip2file_tray.py
 # build: pyinstaller clip2file_tray.py --onefile --noconsole \
-#        --add-data "../assets/icon.ico;." --add-data "../assets/spinner.gif;."
+#        --add-data "../../assets/icon.ico;." --add-data "../../assets/spinner.gif;."

--- a/src/pasteasfile/spinner.py
+++ b/src/pasteasfile/spinner.py
@@ -1,14 +1,14 @@
 # spinner.py
 
-import threading, tkinter as tk, sys, os
+import threading, tkinter as tk, sys, os, pathlib
 from PIL import Image, ImageTk
 
 # SPINNER_PATH = "spinner.gif"
 if getattr(sys, "frozen", False):
-    base_path = sys._MEIPASS
+    base_path = pathlib.Path(sys._MEIPASS)
 else:
-    base_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "assets")
-SPINNER_PATH = os.path.join(base_path, "spinner.gif")
+    base_path = pathlib.Path(__file__).resolve().parents[2] / "assets"
+SPINNER_PATH = base_path / "spinner.gif"
 DURATION_MS  = 1000            # how long to keep it on-screen
 ARC_MS       = 40             # frame delay
 
@@ -22,7 +22,7 @@ def _overlay():
     w, h = 80, 80
     sw, sh = root.winfo_screenwidth(), root.winfo_screenheight()
     root.geometry(f"{w}x{h}+{(sw-w)//2}+{sh-h-60}")
-    gif = Image.open(SPINNER_PATH)
+    gif = Image.open(str(SPINNER_PATH))
     frames = []
     try:
         while True:


### PR DESCRIPTION
## Summary
- resolve asset directory by climbing three levels
- update icon and spinner paths
- fix PyInstaller comments

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850a1ea2c44832a9b4c349b4d8e05b2