### PR TITLE
Add quick extension chooser

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A tiny Windows utility that instantly turns your clipboard text into a temporary
 4. The text is saved as a temporary file with the configured extension (``.py`` by default).
 5. That file is copied to your clipboard, ready to be pasted (e.g., into an email attachment, Slack, Discord, etc.).
 
-Right-click the tray icon to quickly switch the default extension. A small dialog lets you pick from common options like `.py`, `.txt` or `.md`, or enter any custom extension.
+Right-click the tray icon to quickly switch the default extension. The tray menu displays the current choice, and a modern dialog lets you pick from common options like `.py`, `.txt`, or `.md`, or enter any custom extension.
 
 ## A Note on Security
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A tiny Windows utility that instantly turns your clipboard text into a temporary
 4. The text is saved as a temporary file with the configured extension (``.py`` by default).
 5. That file is copied to your clipboard, ready to be pasted (e.g., into an email attachment, Slack, Discord, etc.).
 
-Right-click the tray icon to change the default extension if you frequently work with other file types.
+Right-click the tray icon to quickly switch the default extension. A small dialog lets you pick from common options like `.py`, `.txt` or `.md`, or enter any custom extension.
 
 ## A Note on Security
 

--- a/src/pasteasfile/clip2file_tray.py
+++ b/src/pasteasfile/clip2file_tray.py
@@ -79,6 +79,7 @@ def set_default_extension(icon, _item):
             ext = "." + ext
         if ext:
             DEFAULT_EXT = ext
+            icon.update_menu()
         root.destroy()
 
     btn = ttk.Button(frm, text="OK", command=confirm)
@@ -98,7 +99,7 @@ def on_exit(icon, _item):
 def setup_tray():
     image = Image.open(get_asset_path("icon.ico"))
     menu  = pystray.Menu(
-        pystray.MenuItem(lambda: f"Set Extension ({DEFAULT_EXT})", set_default_extension),
+        pystray.MenuItem(lambda item: f"Set Extension ({DEFAULT_EXT})", set_default_extension),
         pystray.MenuItem("Exit", on_exit)
     )
     icon  = pystray.Icon("Paste as File", image, "Paste as File", menu)

--- a/src/pasteasfile/clip2file_tray.py
+++ b/src/pasteasfile/clip2file_tray.py
@@ -5,7 +5,7 @@ import tempfile, subprocess, keyboard, pyperclip, atexit, os, threading, re
 from PIL import Image
 import pystray
 import tkinter as tk
-from tkinter import simpledialog
+from tkinter import ttk
 
 from .spinner import show_spinner
 from .utils import get_asset_path
@@ -40,21 +40,51 @@ def copy_text_as_file():
     show_spinner()
 
 def set_default_extension(icon, _item):
+    """Show a tiny dialog to choose the default file extension."""
     global DEFAULT_EXT
+
     root = tk.Tk()
-    root.withdraw()
-    ext = simpledialog.askstring(
-        "Default Extension",
-        "Enter default file extension (include .)",
-        initialvalue=DEFAULT_EXT,
-        parent=root,
-    )
-    if ext:
+    root.title("Default Extension")
+    root.resizable(False, False)
+
+    frm = ttk.Frame(root, padding=10)
+    frm.pack(fill="both", expand=True)
+
+    ttk.Label(frm, text="Choose extension").pack(anchor="w")
+
+    common = [".py", ".txt", ".md", "Other..."]
+    choice = tk.StringVar(value=DEFAULT_EXT if DEFAULT_EXT in common else "Other...")
+    combo = ttk.Combobox(frm, values=common, textvariable=choice, state="readonly")
+    combo.pack(fill="x", pady=5)
+
+    custom_var = tk.StringVar(value=DEFAULT_EXT if DEFAULT_EXT not in common else "")
+    entry = ttk.Entry(frm, textvariable=custom_var)
+    entry.pack(fill="x")
+
+    def update_state(*_):
+        if choice.get() == "Other...":
+            entry.configure(state="normal")
+            entry.focus()
+        else:
+            entry.configure(state="disabled")
+            custom_var.set(choice.get())
+
+    choice.trace_add("write", update_state)
+    update_state()
+
+    def confirm():
+        ext = custom_var.get() if choice.get() == "Other..." else choice.get()
         ext = ext.strip()
-        if not ext.startswith('.'):
-            ext = '.' + ext
-        DEFAULT_EXT = ext
-    root.destroy()
+        if ext and not ext.startswith("."):
+            ext = "." + ext
+        if ext:
+            DEFAULT_EXT = ext
+        root.destroy()
+
+    btn = ttk.Button(frm, text="OK", command=confirm)
+    btn.pack(pady=8)
+
+    root.mainloop()
 
 def on_exit(icon, _item):
     # clean up files & hooks, stop tray, then fully exit
@@ -68,7 +98,7 @@ def on_exit(icon, _item):
 def setup_tray():
     image = Image.open(get_asset_path("icon.ico"))
     menu  = pystray.Menu(
-        pystray.MenuItem("Set Extension", set_default_extension),
+        pystray.MenuItem(lambda: f"Set Extension ({DEFAULT_EXT})", set_default_extension),
         pystray.MenuItem("Exit", on_exit)
     )
     icon  = pystray.Icon("Paste as File", image, "Paste as File", menu)


### PR DESCRIPTION
## Summary
- implement a small modern dialog using `ttk` widgets to choose the default file extension
- offer quick choices for `.py`, `.txt` and `.md`
- show the current extension in the tray menu
- document the new behaviour in the README

## Testing
- `python -m py_compile src/pasteasfile/clip2file_tray.py`

------
https://chatgpt.com/codex/tasks/task_e_6862398cdf6c832a99a16bb927ddfaaa