### PR TITLE
Implement drag-and-drop overlay

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "pillow",
     "pyperclip",
     "keyboard",
+    "tkinterdnd2",
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pystray
 
 watchdog
 pyinstaller
+tkinterdnd2

--- a/src/pasteasfile/clip2file_tray.py
+++ b/src/pasteasfile/clip2file_tray.py
@@ -7,11 +7,12 @@ import pystray
 import tkinter as tk
 from tkinter import ttk
 
-from .spinner import show_spinner
+from .spinner import show_spinner, show_drag_icon
 from .utils import get_asset_path
 
 TMP_FILES = []
 DEFAULT_EXT = ".py"
+LAST_FILE = None
 
 def copy_text_as_file():
     data = pyperclip.paste()
@@ -38,6 +39,18 @@ def copy_text_as_file():
         creationflags=subprocess.CREATE_NO_WINDOW
     )
     show_spinner()
+    return path
+
+def handle_hotkey():
+    """Create file or show drag icon if a file was just created."""
+    global LAST_FILE
+    if LAST_FILE and os.path.exists(LAST_FILE):
+        show_drag_icon(LAST_FILE)
+        LAST_FILE = None
+    else:
+        path = copy_text_as_file()
+        if path:
+            LAST_FILE = path
 
 def set_default_extension(icon, _item):
     """Show a tiny dialog to choose the default file extension."""
@@ -109,7 +122,7 @@ def setup_tray():
 def main():
     atexit.register(lambda: [os.unlink(f) for f in TMP_FILES if os.path.exists(f)])
     icon = setup_tray()
-    keyboard.add_hotkey("ctrl+alt+v", copy_text_as_file, suppress=False)
+    keyboard.add_hotkey("ctrl+alt+v", handle_hotkey, suppress=False)
     keyboard.wait()          # still blocks, but on_exit will now kill this too
 
 if __name__ == "__main__":

--- a/src/pasteasfile/spinner.py
+++ b/src/pasteasfile/spinner.py
@@ -3,11 +3,13 @@
 import threading
 import tkinter as tk
 from PIL import Image, ImageTk, ImageSequence
+from tkinterdnd2 import Tk, DND_FILES, COPY
 from .utils import get_asset_path
 
 SPINNER_PATH = get_asset_path("spinner.gif")
 DURATION_MS  = 1000            # how long to keep it on-screen
 ARC_MS       = 40             # frame delay
+DRAG_DURATION_MS = 5000       # how long to keep drag icon visible
 
 def _overlay():
     root = tk.Tk()
@@ -39,3 +41,39 @@ def _overlay():
 
 def show_spinner():
     threading.Thread(target=_overlay, daemon=True).start()
+
+
+def _drag_overlay(path: str):
+    root = Tk()
+    root.overrideredirect(True)
+    root.attributes("-topmost", True)
+    key = "#123456"
+    root.configure(bg=key)
+    root.wm_attributes("-transparentcolor", key)
+    w, h = 80, 80
+    sw, sh = root.winfo_screenwidth(), root.winfo_screenheight()
+    root.geometry(f"{w}x{h}+{(sw-w)//2}+{sh-h-60}")
+
+    img = Image.open(get_asset_path("icon.ico")).resize((w, h), Image.Resampling.LANCZOS)
+    icon = ImageTk.PhotoImage(img)
+    lbl = tk.Label(root, image=icon, bg=key)
+    lbl.image = icon
+    lbl.pack(expand=True, fill="both")
+
+    lbl.drag_source_register(1, DND_FILES)
+
+    def drag_init(event):
+        return ((COPY,), (DND_FILES,), (path,))
+
+    lbl.dnd_bind("<<DragInitCmd>>", drag_init)
+
+    def close(_=None):
+        root.destroy()
+
+    root.bind("<FocusOut>", close)
+    root.after(DRAG_DURATION_MS, close)
+    root.mainloop()
+
+
+def show_drag_icon(path: str):
+    threading.Thread(target=_drag_overlay, args=(path,), daemon=True).start()


### PR DESCRIPTION
## Summary
- enable drag-and-drop overlay using tkinterdnd2
- show overlay on second hotkey press
- track last file to allow quick drag
- update dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68623cebb184832a8c714cd03c3266c9